### PR TITLE
Resolve memory leak caused by `UWidgetPrinter` adding itself to the root

### DIFF
--- a/Plugins/GraphPrinter/Source/WidgetPrinter/Private/WidgetPrinter/WidgetPrinters/WidgetPrinter.cpp
+++ b/Plugins/GraphPrinter/Source/WidgetPrinter/Private/WidgetPrinter/WidgetPrinters/WidgetPrinter.cpp
@@ -15,17 +15,15 @@
 
 UWidgetPrinter::UWidgetPrinter()
 {
-	if (!IsTemplate())
-	{
-		// Temporarily excludes the instance from garbage collection to prevent the instance from being destroyed during printer processing.
-		AddToRoot();
-	}
 }
 
 void UWidgetPrinter::PrintWidget(UPrintWidgetOptions* Options)
 {
 	check(IsValid(Options));
 	CachedPrintOptions = Options;
+
+	// Temporarily excludes the instance from garbage collection to prevent the instance from being destroyed during printer processing.
+	AddToRoot();
 
 	InnerPrinter = CreatePrintModeInnerPrinter(
 		FSimpleDelegate::CreateUObject(this, &UWidgetPrinter::CleanupPrinter)


### PR DESCRIPTION
 This root-scope protection is used to ensure that asynchronous `PrintWidget` calls work in a valid context, but for all other usages (`CanPrintWidget`, `RestoreWidget`, `CanRestoreWidget`) the work is synchronous and doesn't require this object to be added to the root at all.

NOTE: There seem to be a couple edge cases, in which a failure of `PrintWidget()` won't call the cleanup function - but the impact of those leaks is one or two objects each time it fails, whereas this global add-to-root results in upwards of 10 UObjects every frame (e.g. during `FGraphPrinterCommandActions::CanCopyAllAreaOfWidgetToClipboard`)