### PR TITLE
Fix clang compiler error related to explicit instantiation of fully qualified template struct in the wrong namespace

### DIFF
--- a/Plugins/GraphPrinter/Source/DetailsPanelPrinter/Private/DetailsPanelPrinter/WidgetPrinters/InnerDetailsPanelPrinter.cpp
+++ b/Plugins/GraphPrinter/Source/DetailsPanelPrinter/Private/DetailsPanelPrinter/WidgetPrinters/InnerDetailsPanelPrinter.cpp
@@ -45,23 +45,20 @@ using TIdentity_T = typename TIdentity<T>::Type;
 	template struct GraphPrinter::Private::TPrivateAccess<&Name, &PREPROCESSOR_REMOVE_OPTIONAL_PARENS(Class)::Member>
 #endif
 
+UE_DEFINE_PRIVATE_MEMBER_PTR(TSharedPtr<SDetailTree>, GGraphPrinter_Hack_DetailsViewBaseDetailTreePtr, SDetailsViewBase, DetailTree);
+UE_DEFINE_PRIVATE_MEMBER_PTR(FDetailNodeList, GGraphPrinter_Hack_DetailsViewBaseRootTreeNodesPtr, SDetailsViewBase, RootTreeNodes);
+UE_DEFINE_PRIVATE_MEMBER_PTR(FDetailsObjectSet, GGraphPrinter_Hack_DetailMultiTopLevelObjectRootNodeRootObjectSetPtr, FDetailMultiTopLevelObjectRootNode, RootObjectSet);
+
 namespace GraphPrinter
 {
-	namespace Hack
-	{
-		UE_DEFINE_PRIVATE_MEMBER_PTR(TSharedPtr<SDetailTree>, DetailsViewBaseDetailTreePtr, SDetailsViewBase, DetailTree);
-		UE_DEFINE_PRIVATE_MEMBER_PTR(FDetailNodeList, DetailsViewBaseRootTreeNodesPtr, SDetailsViewBase, RootTreeNodes);
-		UE_DEFINE_PRIVATE_MEMBER_PTR(FDetailsObjectSet, DetailMultiTopLevelObjectRootNodeRootObjectSetPtr, FDetailMultiTopLevelObjectRootNode, RootObjectSet);
-	}
-	
 	TSharedPtr<SDetailTree> FDetailsViewBaseAccessor::ExtractDetailTree(const TSharedRef<SDetailsViewBase>& DetailsViewBase)
 	{
-		return DetailsViewBase.Get().*Hack::DetailsViewBaseDetailTreePtr;
+		return DetailsViewBase.Get().*GGraphPrinter_Hack_DetailsViewBaseDetailTreePtr;
 	}
 	
 	FDetailNodeList& FDetailsViewBaseAccessor::ExtractRootTreeNodes(const TSharedRef<SDetailsViewBase>& DetailsViewBase)
 	{
-		return DetailsViewBase.Get().*Hack::DetailsViewBaseRootTreeNodesPtr;
+		return DetailsViewBase.Get().*GGraphPrinter_Hack_DetailsViewBaseRootTreeNodesPtr;
 	}
 
 	TArray<const UObject*>& FDetailsViewBaseAccessor::ExtractRootObjectSet(const TSharedRef<FDetailTreeNode>& DetailTreeNode)
@@ -69,7 +66,7 @@ namespace GraphPrinter
 		check(DetailTreeNode->GetNodeType() == EDetailNodeType::Object);
 
 		const TSharedRef<FDetailMultiTopLevelObjectRootNode> DetailMultiTopLevelObjectRootNode = StaticCastSharedRef<FDetailMultiTopLevelObjectRootNode>(DetailTreeNode);
-		FDetailsObjectSet& DetailsObjects = DetailMultiTopLevelObjectRootNode.Get().*Hack::DetailMultiTopLevelObjectRootNodeRootObjectSetPtr;
+		FDetailsObjectSet& DetailsObjects = DetailMultiTopLevelObjectRootNode.Get().*GGraphPrinter_Hack_DetailMultiTopLevelObjectRootNodeRootObjectSetPtr;
 		return DetailsObjects.RootObjects;
 	}
 	


### PR DESCRIPTION
Creating a fully qualified `UE::Core::Private::TPrivateAccess` template instantiation inside the `GraphPointer::Hack` namespace seems to cause a compiler error with clang.

The error looks like this:
```
Compile [x64] Module.DetailsPanelPrinter.cpp
In file included from <path-to>\GraphPrinter\Intermediate\Build\Win64\x64\UnrealEditor\DebugGame\DetailsPanelPrinter\Module.DetailsPanelPrinter.cpp:11:
<path-to>\GraphPrinter\Source\DetailsPanelPrinter\Private\DetailsPanelPrinter\WidgetPrinters\InnerDetailsPanelPrinter.cpp(56,3): error: explicit instantiation of 'TPrivateAccess' not in a namespace enclosing 'Private'
   56 |                 UE_DEFINE_PRIVATE_MEMBER_PTR(TSharedPtr<SDetailTree>, DetailsViewBaseDetailTreePtr, SDetailsViewBase, DetailTree);
      |                 ^
<path-to>\Engine\Source\Runtime\Core\Public\Misc\DefinePrivateMemberPtr.h(60,40): note: expanded from macro 'UE_DEFINE_PRIVATE_MEMBER_PTR'
   60 |     template struct UE::Core::Private::TPrivateAccess<&Name, &UE_REMOVE_OPTIONAL_PARENS(Class)::Member>
      |                                        ^
<path-to>\Engine\Source\Runtime\Core\Public\Misc\DefinePrivateMemberPtr.h(11,9): note: explicit instantiation refers here
   11 |         struct TPrivateAccess
      |                ^
```

There is also a comment in **DefinePrivateMemberPtr.h** where `UE_DEFINE_PRIVATE_MEMBER_PTR` is defined that calls this out:
```
// These should be defined at global scope
```

The fix was to move the pointers to the global scope (which I then prefixed with `GGraphPrinter_Hack_`).